### PR TITLE
Support for client conn interface

### DIFF
--- a/protoc-gen-gogo/grpc/grpc.go
+++ b/protoc-gen-gogo/grpc/grpc.go
@@ -47,7 +47,7 @@ import (
 // It is incremented whenever an incompatibility between the generated code and
 // the grpc package is introduced; the generated code references
 // a constant, grpc.SupportPackageIsVersionN (where N is generatedCodeVersion).
-const generatedCodeVersion = 4
+const generatedCodeVersion = 6
 
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
@@ -112,7 +112,7 @@ func (g *grpc) Generate(file *generator.FileDescriptor) {
 
 	g.P("// Reference imports to suppress errors if they are not otherwise used.")
 	g.P("var _ ", contextPkg, ".Context")
-	g.P("var _ ", grpcPkg, ".ClientConn")
+	g.P("var _ ", grpcPkg, ".ClientConnInterface")
 	g.P()
 
 	// Assert version compatibility.
@@ -155,7 +155,7 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	g.P()
 	g.P(fmt.Sprintf(`// %sClient is the client API for %s service.
 //
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.`, servName, servName))
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConnInterface.NewStream.`, servName, servName))
 
 	// Client interface.
 	if deprecated {
@@ -172,7 +172,7 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 
 	// Client structure.
 	g.P("type ", unexport(servName), "Client struct {")
-	g.P("cc *", grpcPkg, ".ClientConn")
+	g.P("cc ", grpcPkg, ".ClientConnInterface")
 	g.P("}")
 	g.P()
 
@@ -180,7 +180,7 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	if deprecated {
 		g.P(deprecationComment)
 	}
-	g.P("func New", servName, "Client (cc *", grpcPkg, ".ClientConn) ", servName, "Client {")
+	g.P("func New", servName, "Client (cc ", grpcPkg, ".ClientConnInterface) ", servName, "Client {")
 	g.P("return &", unexport(servName), "Client{cc}")
 	g.P("}")
 	g.P()

--- a/protoc-gen-gogo/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-gogo/testdata/deprecated/deprecated.pb.go
@@ -192,15 +192,15 @@ var fileDescriptor_f64ba265cd7eae3f = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // DeprecatedServiceClient is the client API for DeprecatedService service.
 //
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConnInterface.NewStream.
 //
 // Deprecated: Do not use.
 type DeprecatedServiceClient interface {
@@ -209,11 +209,11 @@ type DeprecatedServiceClient interface {
 }
 
 type deprecatedServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
 // Deprecated: Do not use.
-func NewDeprecatedServiceClient(cc *grpc.ClientConn) DeprecatedServiceClient {
+func NewDeprecatedServiceClient(cc grpc.ClientConnInterface) DeprecatedServiceClient {
 	return &deprecatedServiceClient{cc}
 }
 

--- a/protoc-gen-gogo/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-gogo/testdata/grpc/grpc.pb.go
@@ -175,15 +175,15 @@ var fileDescriptor_81ea47a3f88c2082 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // TestClient is the client API for Test service.
 //
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConnInterface.NewStream.
 type TestClient interface {
 	UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error)
 	// This RPC streams from the server only.
@@ -195,10 +195,10 @@ type TestClient interface {
 }
 
 type testClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTestClient(cc *grpc.ClientConn) TestClient {
+func NewTestClient(cc grpc.ClientConnInterface) TestClient {
 	return &testClient{cc}
 }
 

--- a/protoc-gen-gogo/testdata/grpc/grpc_empty.pb.go
+++ b/protoc-gen-gogo/testdata/grpc/grpc_empty.pb.go
@@ -38,23 +38,23 @@ var fileDescriptor_c580a37f1c90e9b1 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // EmptyServiceClient is the client API for EmptyService service.
 //
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConnInterface.NewStream.
 type EmptyServiceClient interface {
 }
 
 type emptyServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewEmptyServiceClient(cc *grpc.ClientConn) EmptyServiceClient {
+func NewEmptyServiceClient(cc grpc.ClientConnInterface) EmptyServiceClient {
 	return &emptyServiceClient{cc}
 }
 


### PR DESCRIPTION
Client conn interface support was added in gRPC support package version 6 (see https://github.com/grpc/grpc-go/commit/7afcfdd66b1241ed5a29e865d838ce19c57fc2d6)